### PR TITLE
feat: basic read-only editor for object files

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -7,10 +7,16 @@ import {
     ServerOptions,
     TransportKind
 } from 'vscode-languageclient/node';
+import { ObjectFileEditorProvider } from './objectFileEditor';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+    // Register custom "editor" for object files. This is really a read-only
+    // view into the file, where we can display arbitrary content, but the
+    // VSCode API formulates this as an editor.
+    context.subscriptions.push(ObjectFileEditorProvider.register(context));
+
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
         path.join('server', 'out', 'server.js')
@@ -37,8 +43,8 @@ export function activate(context: ExtensionContext) {
         synchronize: {
             // Notify the server about file changes to .c0 or .c1 files, for dependencies
             fileEvents: [workspace.createFileSystemWatcher('**/*.c0'),
-                         workspace.createFileSystemWatcher('**/*.c1'),
-                         workspace.createFileSystemWatcher('**/project.txt')]
+            workspace.createFileSystemWatcher('**/*.c1'),
+            workspace.createFileSystemWatcher('**/project.txt')]
         }
     };
 

--- a/client/src/objectFileEditor.ts
+++ b/client/src/objectFileEditor.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+
+export class ObjectFileEditorProvider implements vscode.CustomReadonlyEditorProvider {
+    public static register(context: vscode.ExtensionContext): vscode.Disposable {
+        const provider = new ObjectFileEditorProvider(context);
+        return vscode.window.registerCustomEditorProvider(ObjectFileEditorProvider.viewType, provider);
+    }
+
+    private static readonly viewType = 'c0.objectFile';
+
+    constructor(
+        private readonly context: vscode.ExtensionContext
+    ) {}
+
+    /**
+     * When a document is opened, this is called to allow us to prepare our
+     * custom document model. Then {@linkcode resolveCustomEditor} is called
+     * with this custom model.
+     */
+    openCustomDocument(uri: vscode.Uri, _openContext: vscode.CustomDocumentOpenContext, _token: vscode.CancellationToken): vscode.CustomDocument | Thenable<vscode.CustomDocument> {
+        return new ObjectFile(uri);
+    }
+
+    /**
+     * Invoked subsequent to {@linkcode openCustomDocument} when opening a
+     * document. This controls the webview which is ultimately displayed.
+     */
+    resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): void | Thenable<void> {
+        const displayUri= (document.uri.scheme === 'file') ? document.uri.fsPath : '&lt;filename&gt;';
+
+        webviewPanel.webview.html = `
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>C0 Object File</title> <!-- TODO(cooper): should be document specific? -->
+        </head>
+        <body style="width: 100%;">
+            <main style="text-align: center; margin: auto; width: 90%; position: absolute; top: 50%; bottom: 50%;">
+               This document cannot be opened in VSCode. To see the interface
+               for this object file, run <pre>cc0 -i ${displayUri}</pre>
+               in your terminal.
+            </main>
+        </body>
+        </html>`;
+    }
+}
+
+class ObjectFile implements vscode.CustomDocument {
+    public readonly uri: vscode.Uri;
+
+    constructor(uri: vscode.Uri) {
+        this.uri = uri;
+    }
+
+    public dispose(): void { return; }
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,22 @@
 				"scopeName": "source.bc0",
 				"path": "./syntaxes/BC0.tmLanguage.json"
 			}
-		]
+		],
+        "customEditors": [
+            {
+                "viewType": "c0.objectFile",
+                "displayName": "C0 Object File",
+                "selector": [
+                    {
+                        "filenamePattern": "*.o0"
+                    },
+                    {
+                        "filenamePattern": "*.o1"
+                    }
+                ],
+                "priority": "default"
+            }
+        ]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",


### PR DESCRIPTION
This should prevent the issues we were seeing last semester where students would open and somehow corrupt these files in VSCode.

There are several opportunities for improvement, but I think we can just get this out the door and handle these later:
- we could display the interface in-line instead of directing them to the terminal command (but we should settle on a format first)
- the formatting could be a bit better in whatever we do display
- the URI we display could be improved (relative path; replace home directory path with `~`, etc..)