### PR TITLE
chore: update changelog for 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 *New major feature*: Indentor. "Format document" will now properly indent the document 
 -->
 
+## [2.4.0] - January 26, 2023
+- Attempting to open an `.o0` or `.o1` file will now display a message
+  redirecting the user to use `cc0 -i` in the terminal to view the
+  interface.
+
 ## [2.3.2] - June 15, 2022
 - Fixed the "No README.md" warning being shown at every keystroke for files with no dependencies
 - Fixed the server crashing when typing in //@

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "c0-lsp",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "c0-lsp",
-			"version": "2.3.1",
+			"version": "2.4.0",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
 	"displayName": "C0 VSCode Language Support",
 	"publisher": "15122staff",
 	"description": "C0 IDE features for VSCode",
-    "license": "Apache-2.0",
+	"license": "Apache-2.0",
 	"repository": "https://github.com/cmu15122/c0-lsp-vscode",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"icon": "122.png",
 	"engines": {
 		"vscode": "^1.39.0"
@@ -78,21 +78,21 @@
 				"path": "./syntaxes/BC0.tmLanguage.json"
 			}
 		],
-        "customEditors": [
-            {
-                "viewType": "c0.objectFile",
-                "displayName": "C0 Object File",
-                "selector": [
-                    {
-                        "filenamePattern": "*.o0"
-                    },
-                    {
-                        "filenamePattern": "*.o1"
-                    }
-                ],
-                "priority": "default"
-            }
-        ]
+		"customEditors": [
+			{
+				"viewType": "c0.objectFile",
+				"displayName": "C0 Object File",
+				"selector": [
+					{
+						"filenamePattern": "*.o0"
+					},
+					{
+						"filenamePattern": "*.o1"
+					}
+				],
+				"priority": "default"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Adds a changelog entry for the changes from #10 released as 2.4.0.