### PR TITLE
fix small typo in "continue" statement error message

### DIFF
--- a/server/src/parse/restrictsyntax.ts
+++ b/server/src/parse/restrictsyntax.ts
@@ -643,7 +643,7 @@ export function restrictStatement(lang: Lang, syn: syn.Statement): ast.Statement
             return syn;
         }
         case "ContinueStatement": {
-            atleast(syn, lang, "C1", "'contine'");
+            atleast(syn, lang, "C1", "'continue'");
             return syn;
         }
         default:


### PR DESCRIPTION
I noticed the error message says "contine" instead of "continue", this trivial PR just adds the u back.